### PR TITLE
fix(ligo) Update ligo share link for FA1.2

### DIFF
--- a/docs/token-contracts/fa12/2-fa12-ligo.md
+++ b/docs/token-contracts/fa12/2-fa12-ligo.md
@@ -142,7 +142,7 @@ Tezos smart contract.
 
 [0]: https://tezostaquito.io/
 [1]: https://github.com/ecadlabs/token-contract-example/blob/master/deploy.js
-[2]: https://ide.ligolang.org/p/-hNqhvMFDFdsTULXq4K-KQ
+[2]: https://ide.ligolang.org/p/4n70T9Z_iDwy6hH2Y0b3Pw
 [3]: https://faucet.tzalpha.net/
 [4]: https://gitlab.com/ligolang/ligo-web-ide
 [5]: https://tezostaquito.io/docs/originate


### PR DESCRIPTION
Updated PascaLIGO to access by key instead of using deprecated (removed)
`get_force`

      const src: account = get_force(src, s.ledger);

becomes

      const src: account = case s.ledger[spender] of

Thanks to @claudebarde for assisting with the ligo update.

Note: ide.ligolang.org will be getting updated to the latest compiler today. This new link will throw an error in the ide on compile until it is updated. In the meantime, it can be verified using the starting webide link: https://ide-staging.ligolang.org/p/4n70T9Z_iDwy6hH2Y0b3Pw

Closes #2 

