### PR TITLE
Updated Ligo link FA1.2 with suggested storage and parameter

### DIFF
--- a/docs/token-contracts/fa12/2-fa12-ligo.md
+++ b/docs/token-contracts/fa12/2-fa12-ligo.md
@@ -142,7 +142,7 @@ Tezos smart contract.
 
 [0]: https://tezostaquito.io/
 [1]: https://github.com/ecadlabs/token-contract-example/blob/master/deploy.js
-[2]: https://ide.ligolang.org/p/_wMhdw_cuHep0cwdmgIWQA
+[2]: https://ide.ligolang.org/p/uTvIQyPWUHjWInqKTUcpwA
 [3]: https://faucet.tzalpha.net/
 [4]: https://gitlab.com/ligolang/ligo-web-ide
 [5]: https://tezostaquito.io/docs/originate

--- a/docs/token-contracts/fa12/2-fa12-ligo.md
+++ b/docs/token-contracts/fa12/2-fa12-ligo.md
@@ -142,7 +142,7 @@ Tezos smart contract.
 
 [0]: https://tezostaquito.io/
 [1]: https://github.com/ecadlabs/token-contract-example/blob/master/deploy.js
-[2]: https://ide.ligolang.org/p/uTvIQyPWUHjWInqKTUcpwA
+[2]: https://ide.ligolang.org/p/o1zxph53rKkwMdO8OFNCzA
 [3]: https://faucet.tzalpha.net/
 [4]: https://gitlab.com/ligolang/ligo-web-ide
 [5]: https://tezostaquito.io/docs/originate


### PR DESCRIPTION
I updated the link that points to the FA1.2 contract on the LIGO web-ide with suggested storage and parameters.