### PR TITLE
Implement og:image workaround for Facebook crawler

### DIFF
--- a/website/static/index.html
+++ b/website/static/index.html
@@ -9,6 +9,10 @@
     <script type="text/javascript">
       window.location.href = 'docs/intro';
     </script>
+    <meta property="og:title" content="Digital Assets on Tezos">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="Welcome to the Digital Assets Portal!">
+    <meta property="og:image" content="https://assets.tqtezos.com/img/tezos-social.jpg">
     <title>Digital Assets on Tezos</title>
   </head>
   <body>


### PR DESCRIPTION
Facebook crawler was not waiting for Docusaurus `siteConfig.js` to run -- added og tags directly into HTML.