### PR TITLE
Mention tezos-packaging brew tap in docs

### DIFF
--- a/docs/setup/1-tezos-client.md
+++ b/docs/setup/1-tezos-client.md
@@ -20,8 +20,7 @@ $ brew tap serokell/tezos-packaging https://github.com/serokell/tezos-packaging.
 $ brew install tezos-client
 ```
 
-`tezos-packaging` provides prebuilt brew bottles for some of the macOS versions
-(Mojave and Catalina at the moment).
+`tezos-packaging` also provides prebuilt brew bottles for some macOS versions.
 
 ### Linux (64-bit)
 

--- a/docs/setup/1-tezos-client.md
+++ b/docs/setup/1-tezos-client.md
@@ -16,9 +16,12 @@ interface to Tezos.
 With [Homebrew](https://brew.sh):
 
 ```shell
-$ brew tap tqtezos/homebrew-tq https://github.com/tqtezos/homebrew-tq.git
-$ brew install tezos
+$ brew tap serokell/tezos-packaging https://github.com/serokell/tezos-packaging.git
+$ brew install tezos-client
 ```
+
+`tezos-packaging` provides prebuilt brew bottles for some of the macOS versions
+(Mojave and Catalina at the moment).
 
 ### Linux (64-bit)
 


### PR DESCRIPTION
Problem: `tqtezos/homebrew-tq` is outdated and doesn't seem to be
maintained anymore.

Solution: Change instruction to point them at the tap provided by the
tezos-packaging repository.

Resolves #37.