### PR TITLE
Remove redundant and erroneous function call from FA1.2 Doc Tutorial

### DIFF
--- a/docs/token-contracts/fa12/2-fa12-ligo.md
+++ b/docs/token-contracts/fa12/2-fa12-ligo.md
@@ -94,14 +94,13 @@ convenient for development and testing, but use in production is
 discouraged. Use a real wallet or HSM backed remote signer for production.
 
 ```js
-const { InMemorySigner, importKey } = require("@taquito/signer")
+const { importKey } = require("@taquito/signer")
 const fs = require("fs")
 const { email, password, mnemonic, secret } = JSON.parse(
   fs.readFileSync("./faucet.json").toString()
 )
 
 const Tezos = new TezosToolkit("https://api.tez.ie/rpc/edonet")
-Tezos.setProvider({ signer: new InMemorySigner() })
 
 importKey(Tezos, email, password, mnemonic.join(" "), secret)
 ```


### PR DESCRIPTION
# Problem

While learning about the Tezos developer ecosystem, I've discovered what I believe to be an error in the documentation page found here:

https://assets.tqtezos.com/docs/token-contracts/fa12/2-fa12-ligo/

The code to highlight is:

```javascript
const { InMemorySigner, importKey } = require("@taquito/signer")
const fs = require("fs")
const { email, password, mnemonic, secret } = JSON.parse(
  fs.readFileSync("./faucet.json").toString()
)

const Tezos = new TezosToolkit("https://api.tez.ie/rpc/edonet")
Tezos.setProvider({ signer: new InMemorySigner() })

importKey(Tezos, email, password, mnemonic.join(" "), secret)
```

I believe the call to `Tezos.setProvider(...)` is unnecessary for two reasons:
1. The documentation for `importKey` states that the function has a "side-effect" of setting the Tezos instance's signer to the InMemorySigner making the `Tezos.setProvider(...` call redundant.
2. Per the most [current docs](https://tezostaquito.io/typedoc/classes/_taquito_signer.inmemorysigner.html#constructor), it is incorrect to call the InMemorySigner constructor with no arguments.

# Solution
My pull request removes the redundant call and the InMemorySigner import.