### PR TITLE
Update instructions for setting up the sandbox

### DIFF
--- a/docs/setup/2-sandbox.md
+++ b/docs/setup/2-sandbox.md
@@ -27,10 +27,17 @@ docker run --rm --name my-sandbox --detach -p 20000:20000 \
        tqtezos/flextesa:20210602 flobox start
 ```
 
-After a few seconds this should succeed:
+After a few seconds this should succeed. If you've used tezos-client
+to connect to a node in the past, run the following to clean-up any
+left-over configuration:
 
 ```shell
 tezos-client config reset        # Cleans-up left-over configuration.
+```
+
+Bootsrap the sandbox. Some operations are only available when the node is bootstrapped:
+
+```
 tezos-client --endpoint http://localhost:20000 bootstrapped
 ```
 


### PR DESCRIPTION
One of the first instructions is to run:
```
tezos-client config reset
```

However, this command will fail if the end-user has never connected to a node before:
```
% tezos-client config reset
Warning:
  Failed to acquire the protocol version from the node
  Rpc request failed:
     - meth: GET
     - uri: http://localhost:8732/chains/main/blocks/head/protocols
     - error: Unable to connect to the node: "Unix.Unix_error(Unix.ECONNREFUSED, "connect", "")"
```

I segmented this step and noted that it only has to be run when tezos-client has been configured previously to connect to a node.