### PR TITLE
[Docs] Fixed Ligo Share link to version without syntax error

### DIFF
--- a/docs/token-contracts/fa12/2-fa12-ligo.md
+++ b/docs/token-contracts/fa12/2-fa12-ligo.md
@@ -149,7 +149,7 @@ Tezos smart contract.
 
 [0]: https://tezostaquito.io/
 [1]: https://github.com/ecadlabs/token-contract-example/blob/master/deploy.js
-[2]: https://ide.ligolang.org/p/o1zxph53rKkwMdO8OFNCzA
+[2]: https://ide.ligolang.org/p/aH_t20VC4iUxC3IRU8-s2g
 [3]: https://faucet.tzalpha.net/
 [5]: https://tezostaquito.io/docs/originate
 [PascaLIGO]: https://ligolang.org/


### PR DESCRIPTION
Updated link to LIGO share to point to updated version that fixed const declaration syntax error.

Old Url: https://ide.ligolang.org/p/o1zxph53rKkwMdO8OFNCzA
Old Code: `const senderAccount : account = getAccount(from_, s);`

New Url: https://ide.ligolang.org/p/aH_t20VC4iUxC3IRU8-s2g
New Code: `var senderAccount : account := getAccount(from_, s);`