### PR TITLE
Updated docs for Mac.

### DIFF
--- a/docs/setup/1-tezos-client.md
+++ b/docs/setup/1-tezos-client.md
@@ -16,7 +16,7 @@ interface to Tezos.
 With [Homebrew](https://brew.sh):
 
 ```shell
-$ brew tap serokell/tezos-packaging-stable https://github.com/serokell/tezos-packaging.git
+$ brew tap serokell/tezos-packaging-stable https://github.com/serokell/tezos-packaging-stable.git
 $ brew install tezos-client
 ```
 


### PR DESCRIPTION
https://assets.tqtezos.com/docs/setup/1-tezos-client/ contains a recommendation to brew tap https://github.com/serokell/tezos-packaging.git which is not stable. 

It is broken at this moment, 

`brew tap serokell/tezos-packaging-stable https://github.com/serokell/tezos-packaging.git`

fails with error.

My suggestion to fix this:
At https://github.com/serokell/tezos-packaging/blob/master/docs/distros/macos.md you can see that recommended URL for a brew tap is **https://github.com/serokell/tezos-packaging-stable.git** which is working fine for me. My suggestion is to update brew tap URL at https://assets.tqtezos.com/docs/setup/1-tezos-client/.